### PR TITLE
github: stop building in containers set up by Github

### DIFF
--- a/.github/actions/build-repo/action.yaml
+++ b/.github/actions/build-repo/action.yaml
@@ -32,13 +32,17 @@ runs:
   steps:
     - name: Build RPM packages
       shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
       run: |
-        IN_CONTAINER=1 ./tool build
+        ./tool build
     - name: Build repository tarball
       shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
       run: |
-        IN_CONTAINER=1 ./tool createrepo
-        IN_CONTAINER=1 ./tool repoconf ${{ inputs.repo_url }} > repo/snapd.repo
+        ./tool createrepo
+        ./tool repoconf ${{ inputs.repo_url }} > repo/snapd.repo
         case ${{ inputs.target }} in
         amazonlinux:2|amazonlinux:2023)
             ;;
@@ -49,7 +53,7 @@ runs:
         esac
         tar -cJv repo > "${{ inputs.repo_tarball_name }}"
     - name: Uploading repository tarball
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.repo_artifact_name }}
         path: "amazon-linux-*-repo*.tar.xz"

--- a/.github/actions/build-repo/action.yaml
+++ b/.github/actions/build-repo/action.yaml
@@ -35,13 +35,18 @@ runs:
       env:
         TARGET: ${{ inputs.target }}
       run: |
+        # note, the 'rpmbuild' directory will be owned by root:root
         ./tool build
     - name: Build repository tarball
       shell: bash
       env:
         TARGET: ${{ inputs.target }}
       run: |
+        # note, the 'repo' directory will be owned by root:root
         ./tool createrepo
+        # fix the permissions
+        sudo chown -R $(id -u):$(id -g) repo
+
         ./tool repoconf ${{ inputs.repo_url }} > repo/snapd.repo
         case ${{ inputs.target }} in
         amazonlinux:2|amazonlinux:2023)

--- a/.github/workflows/buildrepo.yaml
+++ b/.github/workflows/buildrepo.yaml
@@ -27,19 +27,9 @@ jobs:
             repo_url_suffix: al2023
 
     runs-on: ubuntu-latest
-    container: ${{ matrix.target }}
-    env:
-      # the steps are executed inside the container, in case of AMZN2, node20
-      # build provided by github requires newer glibc than present in the
-      # container, so we must use a workaround, see:
-      # https://github.com/actions/checkout/issues/1809
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ matrix.target == 'amazonlinux:2' && 'true' || '' }}
     steps:
-    - name: Install git
-      run: |
-        yum install git -y
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build repository artifacts
       id: build-repo
       uses: "./.github/actions/build-repo"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,16 +39,9 @@ jobs:
             repo_url_suffix: al2023
 
     runs-on: ubuntu-latest
-    container: ${{ matrix.target }}
-    env:
-      # see the comment in buildrepo workflow
-      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: ${{ matrix.target == 'amazonlinux:2' && 'true' || '' }}
     steps:
-    - name: Install git
-      run: |
-        yum install git -y
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Build repository artifacts
       id: build-repo
       uses: "./.github/actions/build-repo"

--- a/spread.yaml
+++ b/spread.yaml
@@ -45,7 +45,7 @@ prepare: |
       case "$SPREAD_SYSTEM" in
           amazon-linux-2023-*)
               # TODO make this automatic
-              dnf upgrade --releasever=2023.5.20240903 -y
+              dnf upgrade --releasever=latest -y
               REBOOT
               ;;
       esac


### PR DESCRIPTION
When using a container set up by Github action runner, all the execution steps are run in that container. However, due to deprecation of node16, and node20 by default, the action/checkout fails inside Amazon Linux container as node20 binaries are built against a newer glibc.

The workaround using ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION no longer works.

Rework the actions to run on ubuntu-latest, and rely on the `tool`'s support for spinning up containers directly through docker/podman.