### PR TITLE
github: update deploy to use download-artifact@v4

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
 
       - name: Prepare the artifacts
         run: |


### PR DESCRIPTION
Update download-artifact action to v4, for compatibility with upload-artifact@v4.